### PR TITLE
add maestro rpc section

### DIFF
--- a/developers/testnet/onboarding-guide.md
+++ b/developers/testnet/onboarding-guide.md
@@ -10,20 +10,24 @@
 
 This guide contains the relevant sections for how to connect to the Arch testnet RPC service, obtain testnet funds, and view transaction activity on the Arch block explorer.
 
-The Arch testnet is designed to help builder teams deploy their programs and test app functionality on a live network. 
-
+The Arch testnet is designed to help builder teams deploy their programs and test dapp functionality on a live network. 
 
 ## RPC Endpoints
 
 | Provider | URL |
 |--------|--------|
+| Maestro | <https://arch-testnet.gomaestro-api.org/v0>
 | Arch | <https://rpc-01.test.arch.network/> |
 | Local | <http://localhost:9001/> |
 
-:::warning
-While you can rely on the RPC service provided by the Arch team, there is also an option to run your own RPC node. 
+[Maestro] is a leading Web3 infrastructure provider specializing in UTxO-based blockchains, including Bitcoin, Cardano, Dogecoin and Arch. Maestro offers a versatile suite of powerful APIs and advanced developer tools that streamline dApp development, empowering businesses to leverage the full potential of blockchain technology. 
 
-In the spirit of true decentralization, this approach provides the added benefit of resilience; should Arch's public RPC experience an outage, your dapp (and users) would not be impacted as a result.
+[Sign-up] for an account and consult the [docs] for how to get started using Maestro as your Arch RPC provider.
+
+:::info
+While you can rely on the RPC service provided by the Arch team as well as Maestro, there is also an option to run your own RPC node. 
+
+In the spirit of true decentralization, this approach provides the added benefit of resilience; should the other RPC services experience an outage, your dapp (and users) would not be impacted as a result.
 :::
 
 ## Bitcoin Testnet4 Faucet
@@ -43,4 +47,7 @@ The Arch Network explorer is coming soon.
 [RPC Endpoints]: #rpc-endpoints
 [Bitcoin Testnet4 Faucet]: #bitcoin-testnet4-faucet
 [Explorers]: #explorers
+[Maestro]: https://gomaestro.org
+[Sign-up]: https://dashboard.gomaestro.org/login
+[docs]: https://docs.gomaestro.org
 [testnet4 mempool.space faucet]: https://mempool.space/testnet4/faucet


### PR DESCRIPTION
This PR adds [Maestro](https://gomaestro.org) to the RPC provider section of the developer testnet guide.