### PR TITLE
Fix typo: Correct "Bitcon" to "Bitcoin" in onboarding guide

### DIFF
--- a/developers/testnet/onboarding-guide.md
+++ b/developers/testnet/onboarding-guide.md
@@ -77,7 +77,7 @@ The source code for this indexer can be found in our [arch-rust-indexer] repo.
 ### Bitcoin
 Should developers need to index the Bitcoin chain, the following resources are available for accessing indexed chain data, both mainnet and testnet4.
 
-- [Bitcon Indexer API - Maestro]
+- [Bitcoin Indexer API - Maestro]
 
 ## Explorers
 
@@ -106,4 +106,4 @@ The Arch Network explorer is coming soon.
 [Ordinals Explorer - Saturn]: https://ord-testnet4.saturnbtc.io/
 [Inscriptions Indexer API - Maestro]: https://docs.gomaestro.org/bitcoin/api-reference#6kTut
 [Runes Indexer API - Maestro]: https://docs.gomaestro.org/bitcoin/api-reference#Kzjqx
-[Bitcon Indexer API - Maestro]: https://docs.gomaestro.org/bitcoin/api-reference#TekXe
+[Bitcoin Indexer API - Maestro]: https://docs.gomaestro.org/bitcoin/api-reference#TekXe


### PR DESCRIPTION


**Description:**
This PR fixes a typo in the onboarding-guide.md file where "Bitcon" was incorrectly written instead of "Bitcoin" in two locations:

- Line 80: [Bitcon Indexer API - Maestro] → [Bitcoin Indexer API - Maestro]
- Line 109: [Bitcon Indexer API - Maestro] → [Bitcoin Indexer API - Maestro]

These changes ensure consistent and correct spelling throughout the documentation.
