### PR TITLE
Fix top-level docs sidebar ordering (remove Index, set spec order)

### DIFF
--- a/content/meta.json
+++ b/content/meta.json
@@ -1,6 +1,5 @@
 {
   "pages": [
-    "index",
     "learn",
     "products",
     "partners",

--- a/content/meta.json
+++ b/content/meta.json
@@ -1,0 +1,11 @@
+{
+  "pages": [
+    "index",
+    "learn",
+    "products",
+    "partners",
+    "nodes",
+    "developers",
+    "community"
+  ]
+}


### PR DESCRIPTION
Follow-up to #13. Fixes two TOC issues that surfaced after merge:

## Summary

- **Order top-level docs sections per spec.** Without a root `content/meta.json`, fumadocs was sorting the top-level sidebar alphabetically (Community, Developers, Learn, Nodes, Partners, Product Suite). Added a root `content/meta.json` that pins the order to: Learn -> Product Suite -> Partners -> Nodes -> Developers -> Community.
- **Remove "Index" from docs sidebar.** Initial root meta.json mistakenly included "index" (which maps to `content/index.md`), causing an "Index" entry to render in the docs sidebar. The home page is rendered separately by `src/app/(home)/page.tsx`, so it shouldn't appear in the docs nav.

## Test plan

- [ ] Top-level sidebar shows in this order: Learn, Product Suite, Partners, Nodes, Developers, Community.
- [ ] No "Index" entry appears in the sidebar.
- [ ] All previously-merged pages still render and link correctly.

Made with [Cursor](https://cursor.com)